### PR TITLE
Fix pyopcode macOS build

### DIFF
--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -2,21 +2,9 @@
 
 BUILD_CONFIG=Release
 
-
-PYTHON_INCLUDE="${PREFIX}/include/python${PY_VER}"
-if [ ! -d ${PYTHON_INCLUDE} ]; then
-    PYTHON_INCLUDE="${PREFIX}/include/python${PY_VER}m"
-fi
-
-PYTHON_LIBRARY_EXT="so"
-if [ `uname` = "Darwin" ] ; then
-    PYTHON_LIBRARY_EXT="dylib"
-fi
-
-PYTHON_LIBRARY="${PREFIX}/lib/libpython${PY_VER}.${PYTHON_LIBRARY_EXT}"
-if [ ! -f ${PYTHON_LIBRARY} ]; then
-    PYTHON_LIBRARY="${PREFIX}/lib/libpython${PY_VER}m.${PYTHON_LIBRARY_EXT}"
-fi
+# use globs to take into account various possible suffixes: m, u, d
+PYTHON_LIBRARY=`ls -d ${PREFIX}/lib/libpython* | head -n 1`
+PYTHON_INCLUDE=`ls -d ${PREFIX}/include/python* | head -n 1`
 
 cd pyopcode
 mkdir build

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -10,10 +10,15 @@ cd pyopcode
 mkdir build
 cd build
 
+if [ `uname` = "Darwin" ]; then
+    # Specify same compiler as with which boost (1.61) is compiled
+    CXX_FLAGS="${CXX_FLAGS} -stdlib=libstdc++"
+fi
+
 cmake ../src \
     -Wno-dev \
     -DCMAKE_BUILD_TYPE=${BUILD_CONFIG} \
-    -DCMAKE_CXX_FLAGS="-Wreturn-type" \
+    -DCMAKE_CXX_FLAGS="${CXX_FLAGS} -Wreturn-type" \
     ${MACOSX_DEPLOYMENT_TARGET:+-DCMAKE_OSX_DEPLOYMENT_TARGET='10.9'} \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DPYTHON_INCLUDE_DIR:PATH=${PYTHON_INCLUDE} \

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,36 +1,40 @@
-about:
-  home: hhttps://github.com/ClinicalGraphics/pyopcode
-  license: LGPL
-  summary: OPCODE collision detection wrapped library with numpy bindings
-build:
-  features:
-  - vc9                [win and py27]
-  - vc10               [win and py34]
-  - vc14               [win and py35]
-  number: 1
 package:
   name: pyopcode
   version: 0.3.3
+
+source:
+  path: ..
+
+build:
+  number: 3
+  features:
+  - vc9  # [win and py27]
+  - vc10  # [win and py34]
+  - vc14  # [win and py>=35]
+
 requirements:
   build:
   - python
-  - numpy 1.10*
-  - gcc 4.8.2 [linux]
-  - cmake 3.5*
-  - boost 1.61*
-  - pyyaml 3.11*
   - setuptools
+  - cmake
+  - numpy x.x
+  - boost >=1.61
+  - pyyaml >=3.10
+
   run:
   - python
-  - numpy 1.10*
-  - boost 1.61*
-  - libgcc [linux]
-source:
-  path: ..
+  - numpy x.x
+  - boost >=1.61
+
 test:
   commands:
-  - py.test --pyargs pyopcode
+    - py.test --pyargs pyopcode
   imports:
-  - pyopcode
+    - pyopcode
   requires:
-  - pytest 2.8*
+    - pytest >=3.0
+
+about:
+  home: https://github.com/ClinicalGraphics/pyopcode
+  license: LGPL-3.0
+  summary: OPCODE collision detection wrapped library with numpy bindings (mesh-mesh and mesh-ray)

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,14 +17,14 @@ requirements:
   - python
   - setuptools
   - cmake
-  - numpy x.x
-  - boost >=1.61
-  - pyyaml >=3.10
+  - numpy 1.11.3
+  - boost 1.61.0
+  - pyyaml 3.12
 
   run:
   - python
-  - numpy x.x
-  - boost >=1.61
+  - numpy 1.11.3
+  - boost 1.61.0
 
 test:
   commands:


### PR DESCRIPTION
Updates the recipe with the latest version from the conda-recipes repo. Makes sure that numpy version can be specified at build time and fixes the build on macOS.