### PR TITLE
Fix packaging

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,13 +17,13 @@ requirements:
   - python
   - setuptools
   - cmake
-  - numpy 1.11.3
+  - numpy x.x
   - boost 1.61.0
   - pyyaml 3.12
 
   run:
   - python
-  - numpy 1.11.3
+  - numpy x.x
   - boost 1.61.0
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,12 +1,12 @@
 package:
   name: pyopcode
-  version: 0.3.3
+  version: 0.3.4
 
 source:
   path: ..
 
 build:
-  number: 3
+  number: 0
   features:
   - vc9  # [win and py27]
   - vc10  # [win and py34]

--- a/pyopcode/__init__.py
+++ b/pyopcode/__init__.py
@@ -10,4 +10,4 @@ __email__ = "eelco@clinicalgraphics.com"
 
 pkg_dir = os.path.abspath(os.path.dirname(__file__))
 
-__version__ = '0.3.3'
+__version__ = '0.3.4'


### PR DESCRIPTION
This prepares pyopcode for version 0.3.4 so that the package can be build properly on macOS again.