### PR TITLE
Allow to find boost_python3 component

### DIFF
--- a/pyopcode/src/CMakeLists.txt
+++ b/pyopcode/src/CMakeLists.txt
@@ -3,7 +3,7 @@ project (_pyopcode)
 
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
-find_package(Boost COMPONENTS python REQUIRED)
+find_package(Boost COMPONENTS python${BOOST_PYTHON_SUFFIX} REQUIRED)
 message("Include dirs of boost: " ${Boost_INCLUDE_DIRS} )
 message("Libs of boost: " ${Boost_LIBRARIES} )
 


### PR DESCRIPTION
Starting from boost 1.64 the boost component is named boost_python3 if compiled against python3.
This allows to take this into account in a very simple way by setting BOOST_PYTHON_SUFFIX=3.